### PR TITLE
Fix KissManga chapter numbering regex

### DIFF
--- a/Scrapers/KissManga.py
+++ b/Scrapers/KissManga.py
@@ -47,7 +47,7 @@ class KissManga(Crawler):
 			pass
 
 		if not chapter_number:
-			chapter_number = re.search(r'{} (.*):.*'.format(self.series_info('title')), chapter.a.text).group(1)
+			chapter_number = re.search(r'{} (.*):?.*'.format(self.series_info('title')), chapter.a.text).group(1)
 
 		try:
 			chapter_name = re.search(r'.*: (.*)', chapter.a.text).group(1)


### PR DESCRIPTION
Some manga chapters at KissManga (I tested with Nisekoi) don't use `:`, so I had the same error from this issue: #8

I fixed it by making the `:` optional.
